### PR TITLE
Sync changes

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -801,7 +801,7 @@ function init(self, obj, doc, opts, prefix) {
       init(self, obj[i], doc[i], opts, path + '.');
     } else if (!schemaType) {
       doc[i] = obj[i];
-      if (!strict) {
+      if (!strict && !prefix) {
         self[i] = obj[i];
       }
     } else {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -11132,10 +11132,26 @@ describe('document', function() {
 
     const doc = await Test.findOne();
     doc.co.value = 123;
-    doc.co = doc.co; // < If this line is not present, there is no problem
+    doc.co = doc.co;
     await doc.save();
 
     const res = await Test.findById(doc._id);
     assert.strictEqual(res.co.value, 123);
+  });
+
+  it('avoids setting nested properties on top-level document when init-ing with strict: false (gh-11526) (gh-11309)', async function() {
+    const testSchema = Schema({ name: String }, { strict: false, strictQuery: false });
+    const Test = db.model('Test', testSchema);
+
+    const doc = new Test();
+    doc.init({
+      details: {
+        person: {
+          name: 'Baz'
+        }
+      }
+    });
+
+    assert.strictEqual(doc.name, void 0);
   });
 });

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -159,7 +159,7 @@ function gh11435() {
   interface Item {
     name: string;
   }
-  const ItemSchema = new Schema<Item, Model<Item>, {}>({ name: String });
+  const ItemSchema = new Schema<Item>({ name: String });
 
   ItemSchema.pre('validate', function preValidate() {
     expectType<Model<unknown>>(this.model('Item1'));

--- a/test/types/document.test.ts
+++ b/test/types/document.test.ts
@@ -154,3 +154,14 @@ function gh11085(): void {
   expectError(_id = newUser._id);
   const _id2: Types.ObjectId = newUser._id;
 }
+
+function gh11435() {
+  interface Item {
+    name: string;
+  }
+  const ItemSchema = new Schema<Item, Model<Item>, {}>({ name: String });
+
+  ItemSchema.pre('validate', function preValidate() {
+    expectType<Model<unknown>>(this.model('Item1'));
+  });
+}

--- a/types/document.d.ts
+++ b/types/document.d.ts
@@ -169,6 +169,9 @@ declare module 'mongoose' {
     /** The name of the model */
     modelName: string;
 
+    /** Returns the model with the given name on this document's associated connection. */
+    model<ModelType = Model<unknown>>(name: string): ModelType;
+
     /**
      * Overwrite all values in this document with the values of `obj`, except
      * for immutable properties. Behaves similarly to `set()`, except for it

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -709,6 +709,8 @@ declare module 'mongoose' {
     model?: string | Model<any>;
     /** optional query options like sort, limit, etc */
     options?: any;
+    /** optional boolean, set to `false` to allow populating paths that aren't in the schema */
+    strictPopulate?: boolean;
     /** deep populate */
     populate?: string | PopulateOptions | (string | PopulateOptions)[];
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -757,7 +757,7 @@ declare module 'mongoose' {
   export type PostMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, res: ResType, next: CallbackWithoutResultAndOptionalError) => void | Promise<void>;
   export type ErrorHandlingMiddlewareFunction<ThisType = any, ResType = any> = (this: ThisType, err: NativeError, res: ResType, next: CallbackWithoutResultAndOptionalError) => void;
 
-  class Schema<DocType = any, M = Model<DocType, any, any, any>, TInstanceMethods = any, TQueryHelpers = any> extends events.EventEmitter {
+  class Schema<DocType = any, M = Model<DocType, any, any, any>, TInstanceMethods = {}, TQueryHelpers = {}> extends events.EventEmitter {
     /**
      * Create a new schema
      */
@@ -811,7 +811,7 @@ declare module 'mongoose' {
     method(obj: Partial<TInstanceMethods>): this;
 
     /** Object of currently defined methods on this schema. */
-    methods: { [F in keyof TInstanceMethods]: TInstanceMethods[F] };
+    methods: { [F in keyof TInstanceMethods]: TInstanceMethods[F] } & AnyObject;
 
     /** The original object passed to the schema constructor */
     obj: SchemaDefinition<SchemaDefinitionType<DocType>>;


### PR DESCRIPTION
> Added strictPopulate to PopulateOptions, otherwise given option can't be used in TS projects when enforcing types.
> 
> **Summary**
> 
> When using populate in mongoose 6, the types for populate options might've been overlooked. `PopulateOptions` interface is missing `strictPopulate` prop, so I added one, with description from the doc. Otherwise I can't use populate with given option.
> 
> **Examples**
> 
> ```
> await DocumentModel.findById('some_id')
>   .populate({
>     match: { somePath: { $ne: undefined } } 
>     path: 'somePath',
>     strictPopulate: false
>   })
> ```
> 
> Previously this was not allowed in typescript dev environment due to enforcing of types, and a type error was thrown. Now I added the respective type and all works.
> 
> _**For future reference**_ It seems that the `options?: any` seems to be unnecessary and wrongfully referring to _`options.options`_. But when we look at the current codebase with `strictPopulate` for example, then the value will be taken from `options.strictPopulate`, not _`options.options.strictPopulate`_.
> 
> TL;DR I'd suggest removing the `options?: any` from the `PopulateOptions` entirely and replace it with the specific options (i.e. strictPopulate, like in this PR)